### PR TITLE
Add CMake draft build files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.10)
+project(Run3GameEngine)
+
+# This is a draft CMake build configuration for Run3
+
+# Set C++ standard
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Find Ogre3D 2 package
+find_package(OGRE 2 REQUIRED CONFIG)
+
+# Add source files (this list is incomplete and provided as a starting point)
+file(GLOB_RECURSE RUN3_SOURCES
+    *.cpp
+    *.h
+)
+
+add_executable(run3 ${RUN3_SOURCES})
+
+# Link against Ogre libraries
+target_link_libraries(run3
+    OgreMain
+    OgreOverlay
+    OgreBites
+)
+
+# Additional include directories can be added as needed
+# include_directories(${OGRE_INCLUDE_DIRS})

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Run3 is an open-source game engine built with Ogre and inspired by the Source engine. The project started in 2009 and is licensed under the [MIT License](LICENSE).
 
+An initial CMake build script is provided for users experimenting with Ogre3D 2.
+
 Run3 exists as a `run3_r.exe` executable and related DLLs. There are no dedicated content creation tools; you can work with whichever tools you prefer. Existing utilities include RunEdit (a legacy map editor), RunRepresent (model viewer), FacialAnimation (lip sync), and Run3Mat (a console utility for material batching). Ogitor assists with mapping, CaduneTree for procedural trees, the CEGUI Editor for GUI, and CEGUIMeshViewer for mesh fixing.
 
 ## Documentation

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -7,3 +7,20 @@ This document describes how to build the Run3 Game Engine from source.
 3. Compile the source code and link the engine binaries.
 
 More detailed instructions will be provided in the future.
+
+## Draft CMake Build (Ogre3D 2)
+
+Run3 can be built using CMake. The provided `CMakeLists.txt` is a starting
+point that assumes Ogre3D 2 is installed and available via CMake's
+`find_package` command.
+
+```
+mkdir build
+cd build
+cmake ..
+cmake --build .
+```
+
+This configuration is a work in progress and only covers the basic engine
+sources. You may need to add additional include directories or libraries based
+on your setup.


### PR DESCRIPTION
## Summary
- add a CMakeLists.txt with Ogre3D 2 support
- document CMake build instructions for Ogre3D 2
- mention CMake build script in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68778a4aeb6c8323809aff2999680637